### PR TITLE
Add support for nested output buffers

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -3520,7 +3520,9 @@
 
                 // clean out anything displayed already
                 try {
-                    @ob_clean();
+                    while(ob_get_level() > 0) {
+                        ob_end_clean();
+                    }
                 } catch ( Exception $ex ) { /* do nothing */ }
 
                 if (!$this->htmlOnly && ErrorHandler::isNonPHPRequest()) {


### PR DESCRIPTION
This uses the ob_get_level command to work out how many output
buffers we need to close before we make our own output.
